### PR TITLE
Fixed hardoced architecture and OS in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY pkg/ pkg/
 COPY controllers/ controllers/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
+RUN CGO_ENABLED=0 go build -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details


### PR DESCRIPTION
linux/arm64 image was build for amd64. This created an interesting situation, where the binary for amd64 was embedded in arm64 image, which did not work too well....

Signed-off-by: Jerzy Kołosowski <jerzy@kolosowscy.pl>